### PR TITLE
feat: add stoplight search component

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "author": "Chris Lott <chris@stoplight.io>",
   "dependencies": {
-    "@stoplight/elements": "^5.2.1",
+    "@stoplight/elements": "^5.2.2",
     "@stoplight/prism-http": "^3.3.4",
     "@types/classnames": "^2.2.10",
     "classnames": "^2.2.6",

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,33 +1,52 @@
+import { Search } from '@stoplight/elements';
+import { Button, Icon } from '@stoplight/ui-kit';
 import cn from 'classnames';
 import { Link } from 'gatsby';
 import React from 'react';
 
+import StoplightProvider from './stoplight-provider';
+
 const Header = ({ siteTitle, centered }: { siteTitle: string; centered: boolean }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
   return (
-    <header className="bg-blue-6">
-      <div
-        className={cn('flex items-baseline py-8', {
-          'max-w-6xl mx-auto': centered,
-          'px-10': !centered,
-        })}
-      >
-        <Link to="/" className="text-white reset mr-10 text-xl">
-          <span className="text-white font-bold">{siteTitle}</span>
-        </Link>
+    <>
+      <header className="bg-blue-6">
+        <div
+          className={cn('flex items-baseline py-8', {
+            'max-w-6xl mx-auto': centered,
+            'px-10': !centered,
+          })}
+        >
+          <Link to="/" className="text-white reset mr-10 text-xl">
+            <span className="text-white font-bold">{siteTitle}</span>
+          </Link>
 
-        <Link to="/guides/" className="reset mr-6 text-lg">
-          <span className="text-white">Guides</span>
-        </Link>
+          <Link to="/guides/" className="reset mr-6 text-lg">
+            <span className="text-white">Guides</span>
+          </Link>
 
-        <Link to="/tutorials/" className="reset mr-6 text-lg">
-          <span className="text-white">Tutorials</span>
-        </Link>
+          <Link to="/tutorials/" className="reset mr-6 text-lg">
+            <span className="text-white">Tutorials</span>
+          </Link>
 
-        <Link to="/api-reference/" className="reset mr-6 text-lg">
-          <span className="text-white">API Reference</span>
-        </Link>
-      </div>
-    </header>
+          <Link to="/api-reference/" className="reset mr-6 text-lg">
+            <span className="text-white">API Reference</span>
+          </Link>
+
+          <Button
+            icon={<Icon icon="search" iconSize={14} color="white" />}
+            className="text-white"
+            minimal
+            onClick={() => setIsOpen(true)}
+          />
+        </div>
+      </header>
+
+      <StoplightProvider projectSrn="gh/qualtrics/publicapidocs" path="guides">
+        <Search srn="gh/qualtrics/publicapidocs" isOpen={isOpen} onClose={() => setIsOpen(false)} />
+      </StoplightProvider>
+    </>
   );
 };
 

--- a/src/components/stoplight-page.tsx
+++ b/src/components/stoplight-page.tsx
@@ -1,48 +1,19 @@
 import '@stoplight/elements/styles/elements.css';
 import '../styles/stoplight.css';
 
-import { Page, Provider, TableOfContents } from '@stoplight/elements';
+import { Page, TableOfContents } from '@stoplight/elements';
 import { Docs } from '@stoplight/elements/components/Docs';
 import { TryIt } from '@stoplight/elements/components/TryIt';
-import { Link } from 'gatsby';
-import { dirname, join, resolve } from 'path';
+import { join } from 'path';
 import React from 'react';
+
+import StoplightProvider from './stoplight-provider';
 
 const StoplightPage = ({ projectSrn, nodeUri, path }: { projectSrn: string; nodeUri: string; path: string }) => {
   const srn = join(projectSrn, nodeUri);
 
   return (
-    <Provider
-      host="https://qualtrics.stoplight.io/api"
-      components={{
-        link: ({ node, children }, key) => {
-          // Render a custom link component
-          let url = node.url;
-
-          // Open external links in a new tab
-          if (/^(http|#)/.test(url)) {
-            return (
-              <a href={url} target="_blank" rel="noreferrer noopener">
-                {children}
-              </a>
-            );
-          }
-
-          if (/^\./.test(url)) {
-            // Resolve relative links
-            url = `/${path}${resolve(dirname(nodeUri), url)}`;
-          } else {
-            url = url.replace(projectSrn, `/${path}`);
-          }
-
-          return (
-            <Link key={key} className="reset" to={url} title={node.title}>
-              {children}
-            </Link>
-          );
-        },
-      }}
-    >
+    <StoplightProvider projectSrn={projectSrn} nodeUri={nodeUri} path={path}>
       <div className="flex h-full w-full">
         <TableOfContents srn={decodeURIComponent(srn)} />
 
@@ -60,7 +31,7 @@ const StoplightPage = ({ projectSrn, nodeUri, path }: { projectSrn: string; node
           }}
         />
       </div>
-    </Provider>
+    </StoplightProvider>
   );
 };
 

--- a/src/components/stoplight-provider.tsx
+++ b/src/components/stoplight-provider.tsx
@@ -1,0 +1,49 @@
+import { Provider } from '@stoplight/elements';
+import { Link } from 'gatsby';
+import { dirname, resolve } from 'path';
+import React from 'react';
+
+const StoplightProvider: React.FC<{ projectSrn: string; nodeUri?: string; path: string }> = ({
+  projectSrn,
+  nodeUri,
+  path,
+  children,
+}) => {
+  return (
+    <Provider
+      host="https://qualtrics.stoplight.io/api"
+      components={{
+        link: ({ node, children }, key) => {
+          // Render a custom link component
+          let url = node.url;
+
+          // Open external links in a new tab
+          if (/^(http|#)/.test(url)) {
+            return (
+              <a href={url} target="_blank" rel="noreferrer noopener">
+                {children}
+              </a>
+            );
+          }
+
+          if (nodeUri && /^\./.test(url)) {
+            // Resolve relative links
+            url = `/${path}${resolve(dirname(nodeUri), url)}`;
+          } else {
+            url = url.replace(projectSrn, `/${path}`);
+          }
+
+          return (
+            <Link key={key} className="reset" to={url} title={node.title}>
+              {children}
+            </Link>
+          );
+        },
+      }}
+    >
+      {children}
+    </Provider>
+  );
+};
+
+export default StoplightProvider;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2032,10 +2032,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@stoplight/elements@^5.2.1":
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/@stoplight/elements/-/elements-5.2.1.tgz#489487696dc6b2d77a6f726dfc0a48f26c04c1c7"
-  integrity sha512-H7JEdaUk1oNTYhYT3FgYgXZqYSbkddplkbiY7qu0UHXWiHTpiiuNzUoyX7xR3JklI7TAhyG6pbxGX/9Xuy3U9A==
+"@stoplight/elements@^5.2.2":
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/@stoplight/elements/-/elements-5.2.2.tgz#e25098fc0b4395e8e1579ac810123683137b3f92"
+  integrity sha512-QCjHmkpS7Az1KZKqcrk2JAKkfifAE76KAsBqG3EY+1aRyNP8uZrypyA4/7RgH1FkYMAVvaN3iITffMxUcrNSBA==
   dependencies:
     "@stoplight/json" "^3.6.0"
     "@stoplight/json-ref-resolver" "^3.0.8"
@@ -7492,7 +7492,7 @@ fork-ts-checker-webpack-plugin@1.5.0:
     tapable "^1.0.0"
     worker-rpc "^0.1.0"
 
-form-data@^3:
+form-data@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
   integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
@@ -9127,7 +9127,7 @@ https-proxy-agent@^5.0.0:
     commander "^2.9.0"
     debug "^2.2.0"
     event-stream "3.3.4"
-    form-data "3.0.0"
+    form-data "^3"
     fs-readfile-promise "^2.0.1"
     fs-writefile-promise "^1.0.3"
     har-validator "^5.0.0"


### PR DESCRIPTION
- adds the Stoplight Elements `<Search />` component
- refactors `<Provider />` to `<StoplightProvider />` so we can use it in both the `<StoplightPage />` and `<Header />` components


![2020-05-19 13 21 19](https://user-images.githubusercontent.com/7423098/82363661-c033f080-99d3-11ea-8165-cc335fe36b3e.gif)
