### PR TITLE
fix: improper CSS for Stoplight code block

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "author": "Chris Lott <chris@stoplight.io>",
   "dependencies": {
-    "@stoplight/elements": "^5.2.2",
+    "@stoplight/elements": "^5.2.3",
     "@stoplight/prism-http": "^3.3.4",
     "@types/classnames": "^2.2.10",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2341,10 +2341,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@stoplight/elements@^5.2.2":
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/@stoplight/elements/-/elements-5.2.2.tgz#e25098fc0b4395e8e1579ac810123683137b3f92"
-  integrity sha512-QCjHmkpS7Az1KZKqcrk2JAKkfifAE76KAsBqG3EY+1aRyNP8uZrypyA4/7RgH1FkYMAVvaN3iITffMxUcrNSBA==
+"@stoplight/elements@^5.2.3":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@stoplight/elements/-/elements-5.2.3.tgz#426b14344d0aad5cbc3e5cd78f979fcc1e835d59"
+  integrity sha512-Ty0mFunq/+YkvPH2J0JB1ui1/ioO1+QAnmyOZ67EFee13F6oLBU4VDbHL59sT2shilFsYeBiGVvjx2wwiuJIIg==
   dependencies:
     "@stoplight/json" "^3.6.0"
     "@stoplight/json-ref-resolver" "^3.0.8"
@@ -2354,7 +2354,7 @@
     "@stoplight/path" "^1.3.1"
     "@stoplight/tree-list" "^5.0.3"
     "@stoplight/types" "^11.6.0"
-    "@stoplight/ui-kit" "^2.15.1"
+    "@stoplight/ui-kit" "^2.17.2"
     "@stoplight/yaml" "^3.7.1"
     axios "^0.19.2"
     classnames "^2.2.6"
@@ -2600,10 +2600,10 @@
     "@types/json-schema" "^7.0.4"
     utility-types "^3.10.0"
 
-"@stoplight/ui-kit@^2.15.1":
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/@stoplight/ui-kit/-/ui-kit-2.17.1.tgz#c737e527a6ec6b3bb99a1dad65ca173180b9dfbd"
-  integrity sha512-iuT2+FY4O5yOUPHENcNsCM2ntavKyH3ANToVLQ7SFkkHJ9j3L2B1OpOK4H/uiel3OMLhPQdiECE5dNHIUwe5xQ==
+"@stoplight/ui-kit@^2.17.2":
+  version "2.17.2"
+  resolved "https://registry.yarnpkg.com/@stoplight/ui-kit/-/ui-kit-2.17.2.tgz#9c2ab70204580a3aef1f51e68969b10f248fae59"
+  integrity sha512-u6852If/hK5vktwAGv4FhAFOCq34Am1ZXDkUckarc8lvsegdCoNIkfkTFtznnfDsqYsB7V7GPqzVxjdTwAjZQw==
   dependencies:
     "@blueprintjs/core" "^3.22.3"
     "@blueprintjs/icons" "^3.13.0"
@@ -7981,7 +7981,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@3.0.0, form-data@^3.0.0:
+form-data@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
   integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
@@ -9656,7 +9656,7 @@ https-proxy-agent@^5.0.0:
     commander "^2.9.0"
     debug "^2.2.0"
     event-stream "3.3.4"
-    form-data "3.0.0"
+    form-data "^3"
     fs-readfile-promise "^2.0.1"
     fs-writefile-promise "^1.0.3"
     har-validator "^5.0.0"


### PR DESCRIPTION
[This commit](https://github.com/qualtrics/PublicAPIDocsHosting/commit/6a70870da82619fc6b0d7ae0b0fc1b5501d770d6#diff-8ee2343978836a779dc9f8d6b794c3b2R2604) updated the yarn lock file and upgraded @stoplight/ui-kit to v2.17.1. But that version did not include the correct CSS for rendering code blocks. So I've upgraded the @stoplight/elements library to bundle the correct CSS and opened this PR to pull in those changes.

You can see the results below:


**Before**

![image](https://user-images.githubusercontent.com/7423098/86304687-46e40c00-bbd5-11ea-9678-7aca91ea5a4b.png)


**After**

![image](https://user-images.githubusercontent.com/7423098/86304633-1ac88b00-bbd5-11ea-8336-5bcc23881ce0.png)
