### PR TITLE
Centering headers

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -12,40 +12,47 @@ const Header = ({ siteTitle, centered }: { siteTitle: string; centered: boolean 
   return (
     <>
       <header className="bg-blue-6">
-        <div
-          className={cn('flex items-baseline py-8', {
-            'max-w-6xl mx-auto': centered,
-            'px-10': !centered,
-          })}
-        >
-          <Link to="/" className="reset mr-10">
-            <div style={{ transform: 'translateY(25%)' }}>
-              <Image />
-            </div>
-          </Link>
+        <div            
+              className={cn('flex items-baseline py-8 text-center', {
+              'max-w-6xl mx-auto': centered,
+              'px-10': centered,
+            })}
+          >
+          <div
+            className={cn('flex items-baseline py-8', {
+              'max-w-6xl mx-auto': centered,
+              'px-10': !centered,
+            })}
+          >
+            <Link to="/" className="reset mr-10">
+              <div style={{ transform: 'translateY(25%)' }}>
+                <Image />
+              </div>
+            </Link>
 
-          <Link to="/instructions/" className="reset mr-6 text-lg">
-            <span className="text-white">Instructions</span>
-          </Link>
+            <Link to="/instructions/" className="reset mr-6 text-lg">
+              <span className="text-white">Instructions</span>
+            </Link>
 
-          <Link to="/guides/" className="reset mr-6 text-lg">
-            <span className="text-white">Guides</span>
-          </Link>
+            <Link to="/guides/" className="reset mr-6 text-lg">
+              <span className="text-white">Guides</span>
+            </Link>
 
-          <Link to="/api-reference/" className="reset mr-6 text-lg">
-            <span className="text-white">API Reference</span>
-          </Link>
+            <Link to="/api-reference/" className="reset mr-6 text-lg">
+              <span className="text-white">API Reference</span>
+            </Link>
 
-          <Link to="/sdks/" className="reset mr-6 text-lg">
-            <span className="text-white">SDKs</span>
-          </Link>
+            <Link to="/sdks/" className="reset mr-6 text-lg">
+              <span className="text-white">SDKs</span>
+            </Link>
 
-          <Button
-            icon={<Icon icon="search" iconSize={14} color="white" />}
-            className="text-white"
-            minimal
-            onClick={() => setIsOpen(true)}
-          />
+            <Button
+              icon={<Icon icon="search" iconSize={14} color="white" />}
+              className="text-white"
+              minimal
+              onClick={() => setIsOpen(true)}
+            />
+          </div>
         </div>
       </header>
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -13,9 +13,8 @@ const Header = ({ siteTitle, centered }: { siteTitle: string; centered: boolean 
     <>
       <header className="bg-blue-6">
         <div            
-              className={cn('flex items-baseline py-8 text-center', {
-              'max-w-6xl mx-auto': centered,
-              'px-10': centered,
+              className={cn('flex items-baseline text-center', {
+              'max-w-6xl mx-auto': centered
             })}
           >
           <div

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -19,7 +19,7 @@ const Layout: React.FC<{ centered: boolean }> = ({ children, centered }) => {
 
   return (
     <div className="h-screen flex flex-col">
-      <Header siteTitle={data.site.siteMetadata.title} centered={centered} />
+      <Header siteTitle={data.site.siteMetadata.title} centered={true} />
 
       <main
         className={cn('flex-1', {


### PR DESCRIPTION
In header.tsx, I centered the header by adding a container div and setting text-align on that. 

This by itself worked on the landing page, but it wasn't enough for the other pages. for that I needed to change the layout.tsx

In layout.tsx, it was using the centered value from the calling page (which was set to false). I forced it to be true for only the header here, and that fixes the header in all the other pages. 